### PR TITLE
docs: use real example values in payload

### DIFF
--- a/raml2markdown/src/calendar-api/includes/examples/calendar-create.json
+++ b/raml2markdown/src/calendar-api/includes/examples/calendar-create.json
@@ -1,12 +1,13 @@
 {
   "toIdentity": "<to identity ID>",
-  "title": "<calendar title>",
+  "title": "April fool's day festivities.",
   "startDate": "2019-04-01T12:00:00+02:00",
   "endDate": "2019-04-01T16:00:00+02:00",
-  "repeats": "<repeats>",
-  "content": "<calendar content>",
-  "location": "<location>",
+  "repeats": "R5/2008-03-01T13:00:00Z/P1Y2M10DT2H30M",
+  "content": "April fool's event, held on the courtyard.",
+  "location": "Courtyard at Teststreet 12",
   "cc": [
-    "<list of identity IDs>"
+    "323bde80-4cc2-472e-bb77-e6a3e95a1253",
+    "0827e9c3-9664-479f-b0ec-956a35d72e4b"
   ]
 }

--- a/raml2markdown/src/calendar-api/includes/examples/calendar-update.json
+++ b/raml2markdown/src/calendar-api/includes/examples/calendar-update.json
@@ -1,9 +1,9 @@
 {
-  "type": "<calendar type>",
-  "title": "<calendar title>",
+  "type": "Event",
+  "title": "April fool's day festivities.",
   "startDate": "2019-04-01T12:00:00+02:00",
   "endDate": "2019-04-01T16:00:00+02:00",
-  "repeats": "<repeats>",
-  "content": "<calendar content>",
-  "location": "<location>"
+  "repeats": "R5/2008-03-01T13:00:00Z/P1Y2M10DT2H30M",
+  "content": "April fool's event, held on the courtyard.",
+  "location": "Courtyard at Teststreet 12"
 }

--- a/raml2markdown/src/identity-api/includes/examples/identity-create.json
+++ b/raml2markdown/src/identity-api/includes/examples/identity-create.json
@@ -1,7 +1,7 @@
 {
-  "context": "<Context URL>",
-  "type": "<Identity type>",
-  "name": "<Identity name>",
+  "context": "https://example.com/contexts/type.jsonld",
+  "type": "Building",
+  "name": "Example building",
   "data": {
     "key-1": "Value 1",
     "key-2": "Value 2"

--- a/raml2markdown/src/identity-api/includes/examples/identity-update.json
+++ b/raml2markdown/src/identity-api/includes/examples/identity-update.json
@@ -1,7 +1,7 @@
 {
-  "context": "<Context URL>",
-  "type": "<Identity type>",
-  "name": "<Identity name>",
+  "context": "https://example.com/contexts/type.jsonld",
+  "type": "Building",
+  "name": "Example building",
   "data": {
     "key-1": "Value 1",
     "key-2": "Value 2"

--- a/raml2markdown/src/identity-api/includes/examples/link-create.json
+++ b/raml2markdown/src/identity-api/includes/examples/link-create.json
@@ -1,4 +1,4 @@
 {
-  "context": "<Context URL>",
-  "type": "<Link type>"
+  "context": "https://example.com/contexts/type.jsonld",
+  "type": "Owner"
 }

--- a/raml2markdown/src/message-api/includes/examples/message-create.json
+++ b/raml2markdown/src/message-api/includes/examples/message-create.json
@@ -1,8 +1,9 @@
 {
   "toIdentity": "<to identity ID>",
-  "subject": "<message subject>",
-  "content": "<message content>",
+  "subject": "Go to the grocery store",
+  "content": "Remember to buy milk!",
   "cc": [
-    "<This list should contain a list of strings with user IDs>"
+    "323bde80-4cc2-472e-bb77-e6a3e95a1253",
+    "0827e9c3-9664-479f-b0ec-956a35d72e4b"
   ]
 }

--- a/raml2markdown/src/message-api/includes/examples/message-update.json
+++ b/raml2markdown/src/message-api/includes/examples/message-update.json
@@ -1,4 +1,4 @@
 {
-  "subject": "<message subject>",
-  "content": "<message content>"
+  "subject": "Go to the grocery store",
+  "content": "Remember to buy milk!"
 }

--- a/raml2markdown/src/product-api/includes/examples/product-create.json
+++ b/raml2markdown/src/product-api/includes/examples/product-create.json
@@ -1,16 +1,20 @@
 {
-  "dataContext": "<data context URL>",
-  "parameterContext": "<parameter context URL>",
-  "productCode": "<product code>",
-  "name": "<product name>",
-  "translatorUrl": "<translator URL>",
+  "dataContext": "https://example.com/contexts/product-data.jsonld",
+  "parameterContext": "https://example.com/contexts/product-parameters.jsonld",
+  "productCode": "product-1",
+  "name": "Product name",
+  "translatorUrl": "https://example.com/translator",
   "sharedSecret": "<shared secret>",
   "organizationPublicKeys": [
     {
-      "url": "<public key URL>",
-      "type": "<public key type>"
+      "url": "https://example.com/public-key.pub",
+      "type": "RsaSignature2018"
+    },
+    {
+      "url": "https://example.com/public-key-2.pub",
+      "type": "RsaSignature2018"
     }
   ],
-  "imageUrl": "<image URL>",
-  "description": "<product description>"
+  "imageUrl": "https://example.com/product-image.png",
+  "description": "This is a product that returns the temperature data for ..."
 }


### PR DESCRIPTION
Example requests currently use tagged examples a la "name:" "<product name>". Relace them with actual examples like "name:" "My product name" so that generated code examples would have proper data.

Not all the data can be hardcoded e.g. `toIdentity`. 