### PR TITLE
fix: remove tags from PUT examples

### DIFF
--- a/raml2markdown/src/identity-api/identity-api.raml
+++ b/raml2markdown/src/identity-api/identity-api.raml
@@ -207,7 +207,7 @@ types:
         body:
           example: |
             {
-              "context": "<context URL>"
+              "context": "https://example.com/contexts/type.jsonld"
             }
         responses:
           201:

--- a/raml2markdown/src/product-api/includes/examples/product-update.json
+++ b/raml2markdown/src/product-api/includes/examples/product-update.json
@@ -1,16 +1,20 @@
 {
-  "dataContext": "<data context URL>",
+  "dataContext": "https://example.com/contexts/product-data.jsonld",
   "parameterContext": "<parameter context URL>",
-  "productCode": "<product code>",
+  "productCode": "product-1",
   "sharedSecret": "<shared secret>",
-  "name": "<product name>",
-  "translatorUrl": "<translator URL>",
+  "name": "Product name",
+  "translatorUrl": "https://example.com/translator",
   "organizationPublicKeys": [
     {
-      "url": "<public key URL>",
-      "type": "<public key type>"
+      "url": "https://example.com/public-key.pub",
+      "type": "RsaSignature2018"
+    },
+    {
+      "url": "https://example.com/public-key-2.pub",
+      "type": "RsaSignature2018"
     }
   ],
-  "imageUrl": "<image URL>",
-  "description": "<product description>"
+  "imageUrl": "https://example.com/product-image.png",
+  "description": "This is a product that returns the temperature data for ..."
 }


### PR DESCRIPTION
Fixed:
- missed replacing tags for one PUT request example
- One put example is directly in "identity-api.raml" file. Missed that.

NB! There is no example value for `<sharedSecret>` in `product-api/includes/properties/product.yaml`